### PR TITLE
Fix path references for local images

### DIFF
--- a/group_photo_processor.py
+++ b/group_photo_processor.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 import numpy as np
 from PIL import Image
 import torch
@@ -428,7 +429,8 @@ def main():
     # Initialize the group photo processor
     processor = GroupPhotoProcessor()
     # Use the updated dataset directory
-    input_directory = "/Users/pranjalsharma/Desktop/face recognition copy/group_photos"
+    root_dir = Path(__file__).resolve().parent
+    input_directory = str(root_dir / "group_photos")
 
     if not os.path.exists(input_directory):
         print(f"Input directory '{input_directory}' not found.")

--- a/identiface-platform/Identiface/backend/main.py
+++ b/identiface-platform/Identiface/backend/main.py
@@ -176,7 +176,8 @@ async def get_clusters():
     """Get all face clusters"""
     try:
         # Load cluster data from JSON file (fallback to database if needed)
-        cluster_file = "/Users/pranjalsharma/Desktop/face recognition copy/face_clusters.json"
+        root_dir = Path(__file__).resolve().parents[2]
+        cluster_file = os.path.join(root_dir, "face_clusters.json")
         
         if os.path.exists(cluster_file):
             with open(cluster_file, 'r') as f:
@@ -345,7 +346,8 @@ async def upload_group_photo(file: UploadFile = File(...)):
     """Upload and process a group photo"""
     try:
         # Save uploaded file
-        upload_dir = "/Users/pranjalsharma/Desktop/face recognition copy/group_photos"
+        root_dir = Path(__file__).resolve().parents[2]
+        upload_dir = os.path.join(root_dir, "group_photos")
         os.makedirs(upload_dir, exist_ok=True)
         
         file_path = os.path.join(upload_dir, f"{uuid.uuid4().hex}_{file.filename}")
@@ -366,7 +368,7 @@ async def upload_group_photo(file: UploadFile = File(...)):
             
             # Save face crop
             face_filename = f"upload_{uuid.uuid4().hex[:8]}.jpg"
-            face_path = os.path.join("/Users/pranjalsharma/Desktop/face recognition copy/group_faces", face_filename)
+            face_path = os.path.join(root_dir, "group_faces", face_filename)
             face_data['image'].save(face_path, 'JPEG', quality=95)
             
             # Insert into database

--- a/identiface-platform/backend/debug_images.py
+++ b/identiface-platform/backend/debug_images.py
@@ -9,8 +9,9 @@ from pathlib import Path
 import glob
 
 # Same paths as in main.py
-FACE_IMAGES_DIR = Path("/Users/pranjalsharma/Desktop/face recognition copy/group_faces")
-GROUP_PHOTOS_DIR = Path("/Users/pranjalsharma/Desktop/face recognition copy/group_photos")
+ROOT_DIR = Path(__file__).resolve().parents[2]
+FACE_IMAGES_DIR = Path(os.getenv("FACE_IMAGES_DIR", ROOT_DIR / "group_faces"))
+GROUP_PHOTOS_DIR = Path(os.getenv("GROUP_PHOTOS_DIR", ROOT_DIR / "group_photos"))
 
 def check_directories():
     print("🔍 Checking Image Directories...")

--- a/identiface-platform/backend/main.py
+++ b/identiface-platform/backend/main.py
@@ -24,9 +24,12 @@ app = FastAPI(
     redoc_url="/redoc"
 )
 
-# 🎯 YOUR CROPPED FACES DIRECTORY - UPDATE THIS IF NEEDED
-FACE_IMAGES_DIR = Path("/Users/pranjalsharma/Desktop/face recognition copy/group_faces")
-GROUP_PHOTOS_DIR = Path("/Users/pranjalsharma/Desktop/face recognition copy/group_photos")
+# 🎯 Paths to cropped faces and group photos
+# Use environment variables if provided, otherwise default to directories
+# located at the project root.
+ROOT_DIR = Path(__file__).resolve().parents[2]
+FACE_IMAGES_DIR = Path(os.getenv("FACE_IMAGES_DIR", ROOT_DIR / "group_faces"))
+GROUP_PHOTOS_DIR = Path(os.getenv("GROUP_PHOTOS_DIR", ROOT_DIR / "group_photos"))
 
 UPLOAD_DIR = Path("uploads")
 UPLOAD_DIR.mkdir(exist_ok=True)

--- a/identiface-platform/backend/test_cropped_images.py
+++ b/identiface-platform/backend/test_cropped_images.py
@@ -10,7 +10,8 @@ import glob
 from PIL import Image
 
 # Your exact directory
-FACE_IMAGES_DIR = Path("/Users/pranjalsharma/Desktop/face recognition copy/group_faces")
+ROOT_DIR = Path(__file__).resolve().parents[2]
+FACE_IMAGES_DIR = Path(os.getenv("FACE_IMAGES_DIR", ROOT_DIR / "group_faces"))
 
 def test_cropped_images():
     print("🔍 Testing Cropped Face Images")

--- a/test_crop_and_embed_query.py
+++ b/test_crop_and_embed_query.py
@@ -2,6 +2,7 @@ from group_photo_processor import GroupPhotoProcessor
 import psycopg2
 import numpy as np
 from sklearn.metrics.pairwise import cosine_similarity
+from pathlib import Path
 
 # --- CONFIGURATION ---
 DB_CONFIG = {
@@ -11,7 +12,8 @@ DB_CONFIG = {
     'host': 'localhost',
     'port': 5432
 }
-QUERY_IMAGE_PATH = '/Users/pranjalsharma/Desktop/face recognition copy/facefindr/static/uploads/query_97fa811b-8c8b-42ae-9f22-efb71e2d6c83.jpg'
+ROOT_DIR = Path(__file__).resolve().parent
+QUERY_IMAGE_PATH = str(ROOT_DIR / 'facefindr' / 'static' / 'uploads' / 'query_97fa811b-8c8b-42ae-9f22-efb71e2d6c83.jpg')
 
 def fetch_db_embedding(face_path):
     conn = psycopg2.connect(**DB_CONFIG)

--- a/test_query.py
+++ b/test_query.py
@@ -3,6 +3,7 @@ from PIL import Image
 import torch
 import numpy as np
 import psycopg2
+from pathlib import Path
 # Load model
 device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 model = InceptionResnetV1(pretrained='vggface2').eval().to(device)
@@ -16,7 +17,8 @@ def get_embedding(image_path):
         embedding = model(img_tensor).cpu().numpy().flatten()
     return embedding
 
-query_image_path = '/Users/pranjalsharma/Desktop/face recognition copy/group_photos/begruessung-outreach-gaeste-4-data.jpg'
+ROOT_DIR = Path(__file__).resolve().parent
+query_image_path = str(ROOT_DIR / 'group_photos' / 'begruessung-outreach-gaeste-4-data.jpg')
 query_embedding = get_embedding(query_image_path)
 print("Query embedding (first 10 values):", query_embedding[:10])
 

--- a/testing.py
+++ b/testing.py
@@ -4,6 +4,7 @@ import numpy as np
 from sklearn.metrics.pairwise import cosine_similarity
 import os
 from shutil import copyfile
+from pathlib import Path
 
 # --- CONFIGURATION ---
 DB_CONFIG = {
@@ -13,7 +14,8 @@ DB_CONFIG = {
     'host': 'localhost',
     'port': 5432
 }
-QUERY_IMAGE_PATH = '/Users/pranjalsharma/Desktop/face recognition copy/facefindr/static/uploads/query_97fa811b-8c8b-42ae-9f22-efb71e2d6c83.jpg'
+ROOT_DIR = Path(__file__).resolve().parent
+QUERY_IMAGE_PATH = str(ROOT_DIR / 'facefindr' / 'static' / 'uploads' / 'query_97fa811b-8c8b-42ae-9f22-efb71e2d6c83.jpg')
 
 QUERY_CROP_DIR = "query_crops"
 


### PR DESCRIPTION
## Summary
- reference face and photo directories relative to repo
- patch debug scripts and test utilities with project-relative paths
- adjust example tests to use pathlib
- update group photo processor paths

## Testing
- `python3 -m py_compile identiface-platform/backend/main.py identiface-platform/Identiface/backend/main.py identiface-platform/backend/debug_images.py group_photo_processor.py testing.py test_query.py test_crop_and_embed_query.py identiface-platform/backend/test_cropped_images.py`
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_688c67d389dc83308fa9f9fbea92e8ca