### PR TITLE
Fix result image URLs

### DIFF
--- a/identiface-platform/components/people-gallery.tsx
+++ b/identiface-platform/components/people-gallery.tsx
@@ -7,7 +7,7 @@ import { Badge } from "@/components/ui/badge"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { motion, AnimatePresence } from "framer-motion"
-import { cn } from "@/lib/utils"
+import { cn, normalizeImageUrl } from "@/lib/utils"
 
 interface Face {
   id: string
@@ -197,7 +197,7 @@ export function PeopleGallery({ clusters, onClusterSelect, isLoading, similarity
                           )}
                           <img
                             data-cluster-id={cluster.id}
-                            src={cluster.representative_face.path || "/placeholder.svg"}
+                            src={normalizeImageUrl(cluster.representative_face.path) || "/placeholder.svg"}
                             alt={`Person ${cluster.id}`}
                             className={cn(
                               "w-full h-full object-cover transition-all duration-300",

--- a/identiface-platform/components/search-results.tsx
+++ b/identiface-platform/components/search-results.tsx
@@ -7,7 +7,7 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { motion, AnimatePresence } from "framer-motion"
-import { cn } from "@/lib/utils"
+import { cn, normalizeImageUrl, API_BASE_URL } from "@/lib/utils"
 
 interface Face {
   id: string
@@ -71,11 +71,9 @@ export function SearchResults({ results, isLoading, similarityThreshold, maxResu
   }
 
   const getOriginalPhotoUrl = (face: Face) => {
-    if (face.original_image_path) {
-      const filename = face.original_image_path.split("/").pop() || face.original_image
-      return `http://localhost:8000/api/original-photo/${filename}`
-    }
-    return `http://localhost:8000/api/original-photo/${face.original_image}`
+    const filename =
+      face.original_image_path?.split("/").pop() || face.original_image
+    return `${API_BASE_URL}/api/original-photo/${filename}`
   }
 
   // Filter and limit results based on similarity threshold and max results
@@ -153,7 +151,7 @@ export function SearchResults({ results, isLoading, similarityThreshold, maxResu
                               </div>
                             ) : (
                               <img
-                                src={face.path || "/placeholder.svg"}
+                                src={normalizeImageUrl(face.path) || "/placeholder.svg"}
                                 alt={`Similar face ${face.id}`}
                                 className="w-full h-full object-cover"
                                 onError={() => handleImageError(face.id)}

--- a/identiface-platform/lib/utils.ts
+++ b/identiface-platform/lib/utils.ts
@@ -4,3 +4,25 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000"
+
+/**
+ * Normalize image URLs coming from the backend.
+ * If the URL is relative or points to localhost, prefix it with the
+ * API base URL so images are served from the correct backend host.
+ */
+export function normalizeImageUrl(url: string): string {
+  if (!url) return ""
+  try {
+    const api = new URL(API_BASE_URL)
+    const parsed = new URL(url, API_BASE_URL)
+    parsed.protocol = api.protocol
+    parsed.host = api.host
+    return parsed.toString()
+  } catch {
+    const cleanUrl = url.startsWith("/") ? url : `/${url}`
+    return `${API_BASE_URL}${cleanUrl}`
+  }
+}


### PR DESCRIPTION
## Summary
- handle backend URL replacement via `normalizeImageUrl`
- apply new util in search results and gallery components
- rebuild frontend to verify build

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688c6eb8be008330991ae74310ee08c5